### PR TITLE
Add non-strict mode to ignore non-JSON lines.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,10 +6,23 @@ module.exports = parse
 module.exports.serialize = serialize
 module.exports.parse = parse
 
-function parse() {
-  return split(function(row) {
+function parse(opts) {
+  opts = opts || {}
+  opts.strict = opts.strict !== false
+
+  function strict(row) {
     if (row) return JSON.parse(row)
-  })
+  }
+
+  function nonStrict(row) {
+    try {
+      if (row) return JSON.parse(row)
+    } catch(e) {
+      // ignore
+    }
+  }
+
+  return opts.strict ? split(strict) : split(nonStrict)
 }
 
 function serialize() {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "max ogden",
   "license": "BSD",
   "dependencies": {
-    "split2": "^0.1.1",
+    "split2": "^0.1.2",
     "through2": "^0.5.1"
   },
   "devDependencies": {},

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,8 @@ example newline delimited json:
 {"hello": "world"}
 ```
 
+If you want to discard non-valid JSON messages, you can call `ldj.parse({strict: false})`
+
 usage:
 
 ```js


### PR DESCRIPTION
Sometimes we might get non-JSON lines in the stream and we don't want our program to throw an exception when this happens.

This pull request bumps the version of the split2 module to solve a problem described in mcollina/split2#1
