### PR TITLE
Set license property to SPDX-valid "BSD-2-Clause"

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "tape test.js"
   },
   "author": "max ogden",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "dependencies": {
     "split2": "^0.2.1",
     "through2": "^0.6.1"


### PR DESCRIPTION
Howdy, @maxogden & friends!

Just a tiny PR to bring `package.json` in line with the new npm license metadata guidelines. There are a few "BSD" license variants, but I take it you're after the lean-and-mean [two-clause version](http://spdx.org/licenses/BSD-2-Clause).

Thanks to all for good work ndjson, here and in the spec. I'm using it pretty heavily.