### PR TITLE
Add missing dependency `minimist`

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "split2": "^0.2.1",
-    "through2": "^0.6.1"
+    "through2": "^0.6.1",
+    "minimist": "^1.2.0"
   },
   "devDependencies": {
     "concat-stream": "^1.5.0",


### PR DESCRIPTION
Minimist is `require`d in `cli.js`, but missing from `package.json`