### PR TITLE
upgrade split2 to v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "max ogden",
   "license": "BSD-3-Clause",
   "dependencies": {
-    "split2": "^0.2.1",
+    "split2": "^1.0.0",
     "through2": "^0.6.1",
     "minimist": "^1.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,35 +1,35 @@
 {
   "name": "ndjson",
-  "version": "1.4.3",
   "description": "streaming newline delimited json parser + serializer",
-  "main": "index.js",
-  "scripts": {
-    "test": "tape test.js"
-  },
+  "version": "1.4.3",
+  "author": "max ogden",
   "bin": {
     "ndjson": "cli.js"
   },
-  "author": "max ogden",
-  "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/maxogden/ndjson/issues"
+  },
   "dependencies": {
+    "minimist": "^1.2.0",
     "split2": "^1.0.0",
-    "through2": "^0.6.1",
-    "minimist": "^1.2.0"
+    "through2": "^0.6.1"
   },
   "devDependencies": {
     "concat-stream": "^1.5.0",
     "tape": "^2.13.3"
   },
+  "homepage": "https://github.com/maxogden/ndjson",
+  "keywords": [
+    "ldjson",
+    "ndjson"
+  ],
+  "license": "BSD-3-Clause",
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/maxogden/ndjson.git"
   },
-  "bugs": {
-    "url": "https://github.com/maxogden/ndjson/issues"
-  },
-  "homepage": "https://github.com/maxogden/ndjson",
-  "keywords": [
-    "ndjson",
-    "ldjson"
-  ]
+  "scripts": {
+    "test": "tape test.js"
+  }
 }


### PR DESCRIPTION
split2 v0.2.1 had several KB of save/backup files included in the package:

```
$ ls -lAh node_modules/split2 
total 282K
-rw-r--r-- 1 slang users 2.0K Oct 21 20:54 index.js
-rw-r--r-- 1 slang users 107K Oct 21 20:54 .index.js.un~
-rw-r--r-- 1 slang users  759 Oct 21 20:54 LICENSE
-rw-r--r-- 1 slang users   76 Oct 21 20:54 .npmignore
-rw-r--r-- 1 slang users 1.9K Oct 21 20:54 package.json
-rw-r--r-- 1 slang users 6.0K Oct 21 20:54 .package.json.un~
-rw-r--r-- 1 slang users 2.6K Oct 21 20:54 README.md
-rw-r--r-- 1 slang users  34K Oct 21 20:54 .README.md.un~
-rw-r--r-- 1 slang users 2.8K Oct 21 20:54 test.js
-rw-r--r-- 1 slang users  95K Oct 21 20:54 .test.js.un~
-rw-r--r-- 1 slang users   38 Oct 21 20:54 .travis.yml

```

...and is rather out of date now.
