### PR TITLE
serialize: fix opts passing

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function parse (opts) {
 }
 
 function serialize (opts) {
-  return through.obj(function(obj, enc, cb) {
+  return through.obj(opts, function(obj, enc, cb) {
     cb(null, JSON.stringify(obj) + EOL)
   })
 }


### PR DESCRIPTION
I noticed that passing `{ end: false }` wasn't going to work, this patch should hopefully resolve that. Thanks!

## Fixes
- __serialize__: `opts` was declared but never passed to the underlying `through2` instance. This allows options to be passed directly.