### PR TITLE
Pass constructor options to split2

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function parse (opts) {
     }
   }
 
-  return split(parseRow)
+  return split(parseRow, opts)
 }
 
 function serialize (opts) {


### PR DESCRIPTION
This teeny-tiny pull request allows users to pass stream constructor options, like `highWaterMark`, to `ndjson.parse`. So:

``` javascript
pump(
  fs.createReadStream(path),
  ndjson.parse({strict: true, highWaterMark: 2})
)
```

This is handy where object-lines coming in may be RAM-sucking data monsters more than capable of eating your Node process in default packs of 16.

I ran into this streaming npm package metadata from the registry. Turns out folks love publishing lots 'o versions---sometimes on every green light from CI---with all kind of malarkey in README. 16 packages times versions per package times README KB per package is a lot of README. And there's more than just README data.

Best,

K
